### PR TITLE
RMET-1695 ::: Check Wallet Readiness

### DIFF
--- a/OSPaymentsLib.xcodeproj/project.pbxproj
+++ b/OSPaymentsLib.xcodeproj/project.pbxproj
@@ -9,6 +9,13 @@
 /* Begin PBXBuildFile section */
 		7507FC1B27FC2AAE003809F6 /* OSPaymentsLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7507FC1227FC2AAE003809F6 /* OSPaymentsLib.framework */; };
 		7507FC2127FC2AAE003809F6 /* OSPaymentsLib.h in Headers */ = {isa = PBXBuildFile; fileRef = 7507FC1527FC2AAE003809F6 /* OSPaymentsLib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7509DC7728993C4C005BA0D4 /* PKMerchantCapability+Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7509DC7628993C4C005BA0D4 /* PKMerchantCapability+Adapter.swift */; };
+		7509DC7D28995A07005BA0D4 /* OSPMTAvailabilityDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7509DC7C28995A07005BA0D4 /* OSPMTAvailabilityDelegate.swift */; };
+		7509DC7F28996482005BA0D4 /* OSPMTApplePayConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7509DC7E28996482005BA0D4 /* OSPMTApplePayConfigurationSpec.swift */; };
+		7509DC81289967A6005BA0D4 /* PKPaymentNetwork+Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7509DC80289967A6005BA0D4 /* PKPaymentNetwork+Adapter.swift */; };
+		755A804B289BB96900426EAA /* PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A804A289BB96900426EAA /* PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift */; };
+		755A804D289BBAB300426EAA /* PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A804C289BBAB300426EAA /* PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift */; };
+		755A8050289BBDF000426EAA /* OSPMTApplePayAvailabilityBehaviourSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A804F289BBDF000426EAA /* OSPMTApplePayAvailabilityBehaviourSpec.swift */; };
 		75E4DCB12897C8AD002277FD /* OSPMTPaymentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E4DCB02897C8AD002277FD /* OSPMTPaymentsSpec.swift */; };
 		75EC4D122893FC3C00CF50E2 /* OSPMTPayments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75EC4D112893FC3C00CF50E2 /* OSPMTPayments.swift */; };
 		75EC4D152894143A00CF50E2 /* OSPMTCallbackDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75EC4D142894143A00CF50E2 /* OSPMTCallbackDelegate.swift */; };
@@ -40,6 +47,13 @@
 		7507FC1227FC2AAE003809F6 /* OSPaymentsLib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OSPaymentsLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7507FC1527FC2AAE003809F6 /* OSPaymentsLib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSPaymentsLib.h; sourceTree = "<group>"; };
 		7507FC1A27FC2AAE003809F6 /* OSPaymentsLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OSPaymentsLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7509DC7628993C4C005BA0D4 /* PKMerchantCapability+Adapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PKMerchantCapability+Adapter.swift"; sourceTree = "<group>"; };
+		7509DC7C28995A07005BA0D4 /* OSPMTAvailabilityDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTAvailabilityDelegate.swift; sourceTree = "<group>"; };
+		7509DC7E28996482005BA0D4 /* OSPMTApplePayConfigurationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTApplePayConfigurationSpec.swift; sourceTree = "<group>"; };
+		7509DC80289967A6005BA0D4 /* PKPaymentNetwork+Adapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PKPaymentNetwork+Adapter.swift"; sourceTree = "<group>"; };
+		755A804A289BB96900426EAA /* PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift"; sourceTree = "<group>"; };
+		755A804C289BBAB300426EAA /* PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift"; sourceTree = "<group>"; };
+		755A804F289BBDF000426EAA /* OSPMTApplePayAvailabilityBehaviourSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTApplePayAvailabilityBehaviourSpec.swift; sourceTree = "<group>"; };
 		75E4DCB02897C8AD002277FD /* OSPMTPaymentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTPaymentsSpec.swift; sourceTree = "<group>"; };
 		75EC4D112893FC3C00CF50E2 /* OSPMTPayments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTPayments.swift; sourceTree = "<group>"; };
 		75EC4D142894143A00CF50E2 /* OSPMTCallbackDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSPMTCallbackDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +124,7 @@
 		7507FC1427FC2AAE003809F6 /* OSPaymentsLib */ = {
 			isa = PBXGroup;
 			children = (
+				7509DC7528993C26005BA0D4 /* Extensions */,
 				75EC4D182894155D00CF50E2 /* Error */,
 				75EC4D132894142000CF50E2 /* Protocols */,
 				7507FC1527FC2AAE003809F6 /* OSPaymentsLib.h */,
@@ -122,11 +137,24 @@
 		7507FC1E27FC2AAE003809F6 /* OSPaymentsLibTests */ = {
 			isa = PBXGroup;
 			children = (
+				755A804F289BBDF000426EAA /* OSPMTApplePayAvailabilityBehaviourSpec.swift */,
+				7509DC7E28996482005BA0D4 /* OSPMTApplePayConfigurationSpec.swift */,
 				75EC4D232894449700CF50E2 /* OSPMTApplePayHandlerSpec.swift */,
 				75E4DCB02897C8AD002277FD /* OSPMTPaymentsSpec.swift */,
 				75EC4D252894478200CF50E2 /* OSPMTTestConfigurations.swift */,
 			);
 			path = OSPaymentsLibTests;
+			sourceTree = "<group>";
+		};
+		7509DC7528993C26005BA0D4 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7509DC7628993C4C005BA0D4 /* PKMerchantCapability+Adapter.swift */,
+				755A804A289BB96900426EAA /* PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift */,
+				755A804C289BBAB300426EAA /* PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift */,
+				7509DC80289967A6005BA0D4 /* PKPaymentNetwork+Adapter.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		75EC4D132894142000CF50E2 /* Protocols */ = {
@@ -136,6 +164,7 @@
 				75EC4D142894143A00CF50E2 /* OSPMTCallbackDelegate.swift */,
 				75EC4D162894150F00CF50E2 /* OSPMTHandlerDelegate.swift */,
 				75EC4D2128942C3800CF50E2 /* OSPMTConfigurationDelegate.swift */,
+				7509DC7C28995A07005BA0D4 /* OSPMTAvailabilityDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -180,6 +209,7 @@
 				7507FC0E27FC2AAE003809F6 /* Sources */,
 				7507FC0F27FC2AAE003809F6 /* Frameworks */,
 				7507FC1027FC2AAE003809F6 /* Resources */,
+				75895022289989D200670171 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -305,6 +335,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		75895022289989D200670171 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: Swiftlint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		8B8B158E2E1E8736A3AE4BF3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -334,10 +381,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7509DC7D28995A07005BA0D4 /* OSPMTAvailabilityDelegate.swift in Sources */,
 				75EC4D1A2894156E00CF50E2 /* OSPMTError.swift in Sources */,
+				7509DC7728993C4C005BA0D4 /* PKMerchantCapability+Adapter.swift in Sources */,
+				755A804B289BB96900426EAA /* PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift in Sources */,
 				75EC4D2228942C3800CF50E2 /* OSPMTConfigurationDelegate.swift in Sources */,
 				75EC4D172894150F00CF50E2 /* OSPMTHandlerDelegate.swift in Sources */,
+				755A804D289BBAB300426EAA /* PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift in Sources */,
 				75EC4D1E289416B600CF50E2 /* OSPMTApplePayHandler.swift in Sources */,
+				7509DC81289967A6005BA0D4 /* PKPaymentNetwork+Adapter.swift in Sources */,
 				75EC4D152894143A00CF50E2 /* OSPMTCallbackDelegate.swift in Sources */,
 				75EC4D1C2894160400CF50E2 /* OSPMTActionDelegate.swift in Sources */,
 				75EC4D122893FC3C00CF50E2 /* OSPMTPayments.swift in Sources */,
@@ -349,6 +401,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				75EC4D262894478200CF50E2 /* OSPMTTestConfigurations.swift in Sources */,
+				755A8050289BBDF000426EAA /* OSPMTApplePayAvailabilityBehaviourSpec.swift in Sources */,
+				7509DC7F28996482005BA0D4 /* OSPMTApplePayConfigurationSpec.swift in Sources */,
 				75EC4D242894449700CF50E2 /* OSPMTApplePayHandlerSpec.swift in Sources */,
 				75E4DCB12897C8AD002277FD /* OSPMTPaymentsSpec.swift in Sources */,
 			);

--- a/OSPaymentsLib/Extensions/PKMerchantCapability+Adapter.swift
+++ b/OSPaymentsLib/Extensions/PKMerchantCapability+Adapter.swift
@@ -1,0 +1,18 @@
+import PassKit
+
+extension PKMerchantCapability {
+    static func convert(from text: String) -> PKMerchantCapability? {
+        switch text.lowercased() {
+        case "debit":
+            return .capabilityDebit
+        case "credit":
+            return .capabilityCredit
+        case "3ds":
+            return .capability3DS
+        case "emv":
+            return .capabilityEMV
+        default:
+            return nil
+        }
+    }
+}

--- a/OSPaymentsLib/Extensions/PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift
+++ b/OSPaymentsLib/Extensions/PKPassLibrary+OSPMTWalletAvailabilityDelegate.swift
@@ -1,0 +1,11 @@
+import PassKit
+
+protocol OSPMTWalletAvailabilityDelegate: AnyObject {
+    static func isWalletAvailable() -> Bool
+}
+
+extension PKPassLibrary: OSPMTWalletAvailabilityDelegate {
+    static func isWalletAvailable() -> Bool {
+        Self.isPassLibraryAvailable()
+    }
+}

--- a/OSPaymentsLib/Extensions/PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift
+++ b/OSPaymentsLib/Extensions/PKPaymentAuthorizationController+OSPMTSetupAvailabilityDelegate.swift
@@ -1,0 +1,19 @@
+import PassKit
+
+protocol OSPMTSetupAvailabilityDelegate: AnyObject {
+    static func isPaymentAvailable() -> Bool
+}
+
+protocol OSPMTApplePaySetupAvailabilityDelegate: OSPMTSetupAvailabilityDelegate {
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool
+}
+
+extension PKPaymentAuthorizationController: OSPMTApplePaySetupAvailabilityDelegate {
+    static func isPaymentAvailable() -> Bool {
+        Self.canMakePayments()
+    }
+    
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool {
+        Self.canMakePayments(usingNetworks: networks, capabilities: merchantCapabilities)
+    }
+}

--- a/OSPaymentsLib/Extensions/PKPaymentNetwork+Adapter.swift
+++ b/OSPaymentsLib/Extensions/PKPaymentNetwork+Adapter.swift
@@ -1,0 +1,18 @@
+import PassKit
+
+extension PKPaymentNetwork {
+    static func convert(from text: String) -> PKPaymentNetwork? {
+        switch text.lowercased() {
+        case "amex":
+            return .amex
+        case "discover":
+            return .discover
+        case "visa":
+            return .visa
+        case "mastercard":
+            return .masterCard
+        default:
+            return nil
+        }
+    }
+}

--- a/OSPaymentsLib/OSPMTApplePayHandler.swift
+++ b/OSPaymentsLib/OSPMTApplePayHandler.swift
@@ -1,11 +1,17 @@
-import PassKit
-
 class OSPMTApplePayHandler: NSObject {
-    let configuration: OSPMTApplePayConfiguration
+    let configuration: OSPMTConfigurationDelegate
+    let availabilityBehaviour: OSPMTAvailabilityDelegate
     
-    init(configurationSource: OSPMTConfiguration = Bundle.main.infoDictionary!) {
-        self.configuration = OSPMTApplePayConfiguration(source: configurationSource)
+    init(configuration: OSPMTConfigurationDelegate, availabilityBehaviour: OSPMTAvailabilityDelegate) {
+        self.configuration = configuration
+        self.availabilityBehaviour = availabilityBehaviour
         super.init()
+    }
+    
+    convenience init(configurationSource: OSPMTConfiguration = Bundle.main.infoDictionary!) {
+        let applePayConfiguration = OSPMTApplePayConfiguration(source: configurationSource)
+        let applePayAvailabilityBehaviour = OSPMTApplePayAvailabilityBehaviour(configuration: applePayConfiguration)
+        self.init(configuration: applePayConfiguration, availabilityBehaviour: applePayAvailabilityBehaviour)
     }
 }
 
@@ -13,5 +19,9 @@ class OSPMTApplePayHandler: NSObject {
 extension OSPMTApplePayHandler: OSPMTHandlerDelegate {
     func setupConfiguration() -> Result<String, OSPMTError> {
         !self.configuration.description.isEmpty ? .success(self.configuration.description) : .failure(.invalidConfiguration)
+    }
+    
+    func checkWalletAvailability() -> OSPMTError? {
+        self.availabilityBehaviour.checkWallet() ?? self.availabilityBehaviour.checkPayment() ?? self.availabilityBehaviour.checkPaymentSetup()
     }
 }

--- a/OSPaymentsLib/OSPMTPayments.swift
+++ b/OSPaymentsLib/OSPMTPayments.swift
@@ -25,4 +25,12 @@ extension OSPMTPayments: OSPMTActionDelegate {
             self.delegate.callback(error: error)
         }
     }
+    
+    func checkWalletSetup() {
+        if let error = self.handler.checkWalletAvailability() {
+            self.delegate.callback(error: error)
+        } else {
+            self.delegate.callbackSuccess()
+        }
+    }
 }

--- a/OSPaymentsLib/Protocols/OSPMTActionDelegate.swift
+++ b/OSPaymentsLib/Protocols/OSPMTActionDelegate.swift
@@ -1,3 +1,4 @@
-protocol OSPMTActionDelegate {
+protocol OSPMTActionDelegate: AnyObject {
     func setupConfiguration()
+    func checkWalletSetup()
 }

--- a/OSPaymentsLib/Protocols/OSPMTAvailabilityDelegate.swift
+++ b/OSPaymentsLib/Protocols/OSPMTAvailabilityDelegate.swift
@@ -1,0 +1,34 @@
+import PassKit
+
+protocol OSPMTAvailabilityDelegate: AnyObject {
+    func checkWallet() -> OSPMTError?
+    func checkPayment() -> OSPMTError?
+    func checkPaymentSetup() -> OSPMTError?
+}
+
+class OSPMTApplePayAvailabilityBehaviour: OSPMTAvailabilityDelegate {
+    let configuration: OSPMTApplePayConfiguration
+    let walletAvailableBehaviour: OSPMTWalletAvailabilityDelegate.Type
+    let setupAvailableBehaviour: OSPMTApplePaySetupAvailabilityDelegate.Type
+    
+    init(configuration: OSPMTApplePayConfiguration, walletAvailableBehaviour: OSPMTWalletAvailabilityDelegate.Type = PKPassLibrary.self, setupAvailableBehaviour: OSPMTApplePaySetupAvailabilityDelegate.Type = PKPaymentAuthorizationController.self) {
+        self.configuration = configuration
+        self.walletAvailableBehaviour = walletAvailableBehaviour
+        self.setupAvailableBehaviour = setupAvailableBehaviour
+    }
+    
+    func checkWallet() -> OSPMTError? {
+        return !self.walletAvailableBehaviour.isWalletAvailable() ? .walletNotAvailable : nil
+    }
+    
+    func checkPayment() -> OSPMTError? {
+        return !self.setupAvailableBehaviour.isPaymentAvailable() ? .paymentNotAvailable : nil
+    }
+    
+    func checkPaymentSetup() -> OSPMTError? {
+        guard let supportedNetworks = self.configuration.supportedNetworks, let merchantCapabilities = self.configuration.merchantCapabilities
+        else { return .setupPaymentNotAvailable }
+        return !self.setupAvailableBehaviour.isPaymentAvailable(using: supportedNetworks, and: merchantCapabilities) ?
+            .setupPaymentNotAvailable : nil
+    }
+}

--- a/OSPaymentsLib/Protocols/OSPMTCallbackDelegate.swift
+++ b/OSPaymentsLib/Protocols/OSPMTCallbackDelegate.swift
@@ -1,4 +1,4 @@
-protocol OSPMTCallbackDelegate {
+protocol OSPMTCallbackDelegate: AnyObject {
     func callback(result: String?, error: OSPMTError?)
 }
 

--- a/OSPaymentsLib/Protocols/OSPMTHandlerDelegate.swift
+++ b/OSPaymentsLib/Protocols/OSPMTHandlerDelegate.swift
@@ -1,5 +1,6 @@
 typealias OSPMTCompletionHandler = (Result<Bool, OSPMTError>) -> Void
 
-protocol OSPMTHandlerDelegate {
+protocol OSPMTHandlerDelegate: AnyObject {
     func setupConfiguration() -> Result<String, OSPMTError>
+    func checkWalletAvailability() -> OSPMTError?
 }

--- a/OSPaymentsLibTests/OSPMTApplePayAvailabilityBehaviourSpec.swift
+++ b/OSPaymentsLibTests/OSPMTApplePayAvailabilityBehaviourSpec.swift
@@ -1,0 +1,109 @@
+import Nimble
+import PassKit
+import Quick
+@testable import OSPaymentsLib
+
+class MockWalletAvailableBehaviour: OSPMTWalletAvailabilityDelegate {
+    static var result: Bool = false
+    
+    static func isWalletAvailable() -> Bool {
+        return Self.result
+    }
+}
+
+class MockSetupAvailableBehaviour: OSPMTApplePaySetupAvailabilityDelegate {
+    static var setupAvailable: Bool = false
+    static var paymentAvailable: Bool = false
+    
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool {
+        return Self.setupAvailable
+    }
+    
+    static func isPaymentAvailable() -> Bool {
+        return Self.paymentAvailable
+    }
+}
+
+class OSPMTApplePayAvailabilityBehaviourSpec: QuickSpec {
+    override func spec() {
+        var applePayAvailabilityBehaviour: OSPMTApplePayAvailabilityBehaviour!
+        
+        let mockConfiguration = OSPMTApplePayConfiguration(source: OSPMTTestConfigurations.validNetworkCapabilityConfig)
+        
+        describe("Given an AvailabilityBehaviour") {
+            beforeEach {
+                applePayAvailabilityBehaviour = OSPMTApplePayAvailabilityBehaviour(
+                    configuration: mockConfiguration,
+                    walletAvailableBehaviour: MockWalletAvailableBehaviour.self,
+                    setupAvailableBehaviour: MockSetupAvailableBehaviour.self
+                )
+            }
+            
+            context("When a Wallet is not available") {
+                beforeEach {
+                    MockWalletAvailableBehaviour.result = false
+                }
+                
+                it("should return a WalletNotAvailable error") {
+                    let result = applePayAvailabilityBehaviour.checkWallet()
+                    expect(result).to(equal(.walletNotAvailable))
+                }
+            }
+            
+            context("When a Wallet is available") {
+                beforeEach {
+                    MockWalletAvailableBehaviour.result = true
+                }
+                
+                it("should succeed and return nil") {
+                    let result = applePayAvailabilityBehaviour.checkWallet()
+                    expect(result).to(beNil())
+                }
+            }
+            
+            context("When Payment is not available") {
+                beforeEach {
+                    MockSetupAvailableBehaviour.paymentAvailable = false
+                }
+                
+                it("should return a PaymentNotAvailable error") {
+                    let result = applePayAvailabilityBehaviour.checkPayment()
+                    expect(result).to(equal(.paymentNotAvailable))
+                }
+            }
+            
+            context("When Payment is available") {
+                beforeEach {
+                    MockSetupAvailableBehaviour.paymentAvailable = true
+                }
+                
+                it("should succeed and return nil") {
+                    let result = applePayAvailabilityBehaviour.checkPayment()
+                    expect(result).to(beNil())
+                }
+            }
+            
+            context("When Payment Setup is not available") {
+                beforeEach {
+                    MockSetupAvailableBehaviour.setupAvailable = false
+                }
+                
+                it("should return a PaymentNotAvailable error") {
+                    let result = applePayAvailabilityBehaviour.checkPaymentSetup()
+                    expect(result).to(equal(.setupPaymentNotAvailable))
+                }
+            }
+            
+            context("When Payment Setup is available") {
+                beforeEach {
+                    MockSetupAvailableBehaviour.setupAvailable = true
+                }
+                
+                it("should succeed and return nil") {
+                    let result = applePayAvailabilityBehaviour.checkPaymentSetup()
+                    expect(result).to(beNil())
+                }
+            }
+        }
+    }
+}

--- a/OSPaymentsLibTests/OSPMTApplePayConfigurationSpec.swift
+++ b/OSPaymentsLibTests/OSPMTApplePayConfigurationSpec.swift
@@ -1,0 +1,82 @@
+import Nimble
+import PassKit
+import Quick
+@testable import OSPaymentsLib
+
+class OSPMTApplePayConfigurationSpec: QuickSpec {
+    override func spec() {
+        var applePayConfiguration: OSPMTApplePayConfiguration!
+        
+        describe("Given a correct configuration") {
+            beforeEach {
+                applePayConfiguration = OSPMTApplePayConfiguration(source: OSPMTTestConfigurations.validNetworkCapabilityConfig)
+            }
+            
+            context("When checking the Supported Networks property") {
+                it("should return a valid value") {
+                    expect(applePayConfiguration.supportedNetworks).to(equal([PKPaymentNetwork.visa, .masterCard]))
+                }
+            }
+            
+            context("When checking the Merchant Capabilities property") {
+                it("should return a valid value") {
+                    expect(applePayConfiguration.merchantCapabilities).to(equal([PKMerchantCapability.capability3DS, .capabilityEMV]))
+                }
+            }
+        }
+        
+        describe("Given a configuration with both valid an invalid values") {
+            beforeEach {
+                applePayConfiguration = OSPMTApplePayConfiguration(source: OSPMTTestConfigurations.validNetworkCapabilityWithErrorConfig)
+            }
+            
+            context("When checking the Supported Networks property") {
+                it("should return a valid value without the invalid one") {
+                    expect(applePayConfiguration.supportedNetworks).to(equal([PKPaymentNetwork.visa]))
+                }
+            }
+            
+            context("When checking the Merchant Capabilities property") {
+                it("should return a valid value without the invalid one") {
+                    expect(applePayConfiguration.merchantCapabilities).to(equal(.capability3DS))
+                }
+            }
+        }
+        
+        describe("Given a configuration with an invalid value") {
+            beforeEach {
+                applePayConfiguration = OSPMTApplePayConfiguration(source: OSPMTTestConfigurations.invalidNetworkCapabilityConfig)
+            }
+            
+            context("When checking the Supported Networks property") {
+                it("should return a nil value") {
+                    expect(applePayConfiguration.supportedNetworks).to(beNil())
+                }
+            }
+            
+            context("When checking the Merchant Capabilities property") {
+                it("should return a nil value") {
+                    expect(applePayConfiguration.merchantCapabilities).to(beNil())
+                }
+            }
+        }
+        
+        describe("Given a nil configuration") {
+            beforeEach {
+                applePayConfiguration = OSPMTApplePayConfiguration(source: OSPMTTestConfigurations.invalidNetworkCapabilityConfig)
+            }
+            
+            context("When checking the Supported Networks property") {
+                it("should return a nil value") {
+                    expect(applePayConfiguration.supportedNetworks).to(beNil())
+                }
+            }
+            
+            context("When checking the Merchant Capabilities property") {
+                it("should return a nil value") {
+                    expect(applePayConfiguration.merchantCapabilities).to(beNil())
+                }
+            }
+        }
+    }
+}

--- a/OSPaymentsLibTests/OSPMTTestConfigurations.swift
+++ b/OSPaymentsLibTests/OSPMTTestConfigurations.swift
@@ -6,7 +6,7 @@ struct OSPMTTestConfigurations {
     
     // MARK: - OSPMTApplePayHandlerSpec Configurations
     static let fullConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
@@ -27,7 +27,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noMerchantNameConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.dummyString],
@@ -37,7 +37,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noMerchantCountryCodeConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.dummyString],
@@ -47,7 +47,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noPaymentAllowedNetworksConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.dummyString],
@@ -57,7 +57,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noPaymentSupportedCapabilitiesConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
@@ -67,7 +67,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noPaymentSupportedCardCountriesConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
@@ -77,7 +77,7 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noShippingSupportedContactsConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
@@ -87,12 +87,35 @@ struct OSPMTTestConfigurations {
     ]
     
     static let noBillingSupportedContactsConfig: OSPMTConfiguration = [
-        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID : Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.merchantID: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantName: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.merchantCountryCode: Self.dummyString,
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.dummyString],
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.dummyString],
         OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCardCountries: Self.dummyString + "," + Self.dummyString,
-        OSPMTApplePayConfiguration.ConfigurationKeys.shippingSupportedContacts: Self.dummyString + "," + Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.shippingSupportedContacts: Self.dummyString + "," + Self.dummyString
     ]
+    
+    // MARK: - OSPMTApplePayConfigurationSpec Configurations
+    static let networkVisa = "VISA"
+    static let networkMasterCard = "MasterCard"
+    static let capability3DS = "3DS"
+    static let capabilityEMV = "emv"
+    
+    static let validNetworkCapabilityConfig: OSPMTConfiguration = [
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.networkVisa, Self.networkMasterCard],
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.capability3DS, Self.capabilityEMV]
+    ]
+    
+    static let validNetworkCapabilityWithErrorConfig: OSPMTConfiguration = [
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: [Self.networkVisa, Self.dummyString],
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: [Self.capability3DS, Self.dummyString]
+    ]
+    
+    static let invalidNetworkCapabilityConfig: OSPMTConfiguration = [
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentAllowedNetworks: Self.dummyString,
+        OSPMTApplePayConfiguration.ConfigurationKeys.paymentSupportedCapabilities: Self.dummyString
+    ]
+    
+    static let emptyNetworkCapabilityConfig: OSPMTConfiguration = [:]
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 2022-08-02
+
+- Feat: Check Wallet Availability for Payment (https://outsystemsrd.atlassian.net/browse/RMET-1695).
+
 ### 2022-08-01
 
 - Feat: Setup Apple Pay Configurations (https://outsystemsrd.atlassian.net/browse/RMET-1722).


### PR DESCRIPTION
## Description
Add verification for wallet and payment availability. Payment verification is enhanced by also checking it against the configured payment networks and supported capabilities.

A Sample App build was generated to test this new feature: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=c30092893f37813e608c7f751b4bfd2953fe23e6&StageId=3

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1695

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

# Tests
Add related unit tests to the Payments stack. Regression tests working as expected.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
