### PR TITLE
RMET-1695 ::: Payment Setup Verification Failed on Invalid Configuration

### DIFF
--- a/OSPaymentsLib/Extensions/PKPaymentAuthorizationController+Adapter.swift
+++ b/OSPaymentsLib/Extensions/PKPaymentAuthorizationController+Adapter.swift
@@ -12,8 +12,9 @@ extension PKPaymentAuthorizationController: OSPMTApplePaySetupAvailabilityDelega
     ///   - networks: Array of payment networks available by a merchant
     ///   - merchantCapabilities: Bit set containing the payment capabilities available by a merchant.
     /// - Returns: A boolean indicating if the payment is available.
-    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool {
-        Self.canMakePayments(usingNetworks: networks, capabilities: merchantCapabilities)
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork]?, and merchantCapabilities: PKMerchantCapability?) -> Bool {
+        guard let networks = networks, let merchantCapabilities = merchantCapabilities else { return false }
+        return Self.canMakePayments(usingNetworks: networks, capabilities: merchantCapabilities)
     }
 }
 

--- a/OSPaymentsLib/Protocols/OSPMTAvailabilityDelegate.swift
+++ b/OSPaymentsLib/Protocols/OSPMTAvailabilityDelegate.swift
@@ -23,7 +23,7 @@ protocol OSPMTApplePaySetupAvailabilityDelegate: OSPMTSetupAvailabilityDelegate 
     ///   - networks: Array of payment networks available by a merchant
     ///   - merchantCapabilities: Bit set containing the payment capabilities available by a merchant.
     /// - Returns: A boolean indicating if the payment is available.
-    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork]?, and merchantCapabilities: PKMerchantCapability?) -> Bool
 }
 
 // MARK: - OSPMTAvailabilityDelegate Protocol Methods
@@ -84,9 +84,9 @@ class OSPMTApplePayAvailabilityBehaviour: OSPMTAvailabilityDelegate {
         var error: OSPMTError?
         
         if shouldVerifySetup {
-            if let supportedNetworks = self.configuration.supportedNetworks,
-                let merchantCapabilities = self.configuration.merchantCapabilities,
-                !self.setupAvailableBehaviour.isPaymentAvailable(using: supportedNetworks, and: merchantCapabilities) {
+            if !self.setupAvailableBehaviour.isPaymentAvailable(
+                using: self.configuration.supportedNetworks, and: self.configuration.merchantCapabilities
+            ) {
                 error = .setupPaymentNotAvailable
             }
         } else if !self.setupAvailableBehaviour.isPaymentAvailable() {

--- a/OSPaymentsLibTests/OSPMTApplePayAvailabilityBehaviourSpec.swift
+++ b/OSPaymentsLibTests/OSPMTApplePayAvailabilityBehaviourSpec.swift
@@ -15,7 +15,7 @@ class MockSetupAvailableBehaviour: OSPMTApplePaySetupAvailabilityDelegate {
     static var setupAvailable: Bool = false
     static var paymentAvailable: Bool = false
     
-    static func isPaymentAvailable(using networks: [PKPaymentNetwork], and merchantCapabilities: PKMerchantCapability) -> Bool {
+    static func isPaymentAvailable(using networks: [PKPaymentNetwork]?, and merchantCapabilities: PKMerchantCapability?) -> Bool {
         return Self.setupAvailable
     }
     


### PR DESCRIPTION
## Description
Fix error when verifying payment setup on ReadyToPay method. If some payment network or merchant capabilities are missing, return the associated error.

A Sample App build was generated to test this feature: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=f49a4dfbd8eb5198d3050f48f4f5003c3b12b321

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1695

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
Fix related unit tests. Regression tests working as before.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
