### PR TITLE
RMET-2095 ::: Add Payment Service Provider as TriggerPayment Input Parameter

### DIFF
--- a/OSPaymentsLib/Error/OSPMTError.swift
+++ b/OSPaymentsLib/Error/OSPMTError.swift
@@ -14,6 +14,7 @@ public enum OSPMTError: Int, CustomNSError, LocalizedError {
     case gatewaySetFailed = 12
     case stripePaymentMethodCreation = 13
     case paymentIssue = 14
+    case gatewayNotConfigured = 15
     
     /// Textual description
     public var errorDescription: String? {
@@ -41,6 +42,8 @@ public enum OSPMTError: Int, CustomNSError, LocalizedError {
             return "Couldn't obtain the PaymentMethod from Stripe."
         case .paymentIssue:
             return "Couldn't process payment."
+        case .gatewayNotConfigured:
+            return "Couldn't trigger the payment because the requested payment service provider is not configured."
         }
     }
 }

--- a/OSPaymentsLib/Gateways/OSPMTGateway.swift
+++ b/OSPaymentsLib/Gateways/OSPMTGateway.swift
@@ -8,7 +8,8 @@ extension OSPMTGateway {
     /// Converts a string into a `OSPMTGateway` object.
     /// - Parameter text: Text to convert.
     /// - Returns: A `OSPMTGateway` enum object if successful. `nil` is returned in case of error.
-    static func convert(from text: String) -> OSPMTGateway? {
-        return text.lowercased() == "stripe" ? .stripe : nil
+    static func convert(from text: String?) -> OSPMTGateway? {
+        guard let text = text, text.lowercased() == "stripe" else { return nil }
+        return .stripe
     }
 }

--- a/OSPaymentsLib/Models/OSPMTDetailsModel.swift
+++ b/OSPaymentsLib/Models/OSPMTDetailsModel.swift
@@ -47,6 +47,7 @@ struct OSPMTDetailsModel: Decodable {
     let status: OSPMTStatus
     let shippingContact: OSPMTContact
     let billingContact: OSPMTContact
+    let gateway: OSPMTGateway?
     
     /// Keys used to encode and decode the model.
     enum CodingKeys: String, CodingKey {
@@ -55,6 +56,7 @@ struct OSPMTDetailsModel: Decodable {
         case status
         case shippingContact = "shippingContacts"
         case billingContact = "billingContacts"
+        case gateway = "psp"
     }
     
     /// Constructor method.
@@ -64,12 +66,14 @@ struct OSPMTDetailsModel: Decodable {
     ///   - status: Final value status.
     ///   - shippingContact: Shipping properties required for filling.
     ///   - billingContact: Billiing properties required for filling.
-    init(amount: Decimal, currency: String, status: OSPMTStatus, shippingContact: OSPMTContact, billingContact: OSPMTContact) {
+    ///   - gateway: Payment service provided to be used for processing, if passed.
+    init(amount: Decimal, currency: String, status: OSPMTStatus, shippingContact: OSPMTContact, billingContact: OSPMTContact, gateway: String? = nil) {
         self.amount = amount
         self.currency = currency
         self.status = status
         self.shippingContact = shippingContact
         self.billingContact = billingContact
+        self.gateway = OSPMTGateway.convert(from: gateway)
     }
     
     /// Creates a new instance by decoding from the given decoder.
@@ -85,8 +89,9 @@ struct OSPMTDetailsModel: Decodable {
         let status = try container.decode(OSPMTStatus.self, forKey: .status)
         let shippingContact = try container.decode(OSPMTContact.self, forKey: .shippingContact)
         let billingContact = try container.decode(OSPMTContact.self, forKey: .billingContact)
+        let gateway = try container.decodeIfPresent(String.self, forKey: .gateway)
         self.init(
-            amount: amount, currency: currency, status: status, shippingContact: shippingContact, billingContact: billingContact
+            amount: amount, currency: currency, status: status, shippingContact: shippingContact, billingContact: billingContact, gateway: gateway
         )
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2022-12-12
+- Feat: Add Payment Service Provider property to `OSPMTDetailsModel` struct (https://outsystemsrd.atlassian.net/browse/RMET-2095).
+
 ### 2022-12-02
 - Feat: Add Stripe as Payment Service Provider (https://outsystemsrd.atlassian.net/browse/RMET-2078).
 


### PR DESCRIPTION
## Description
Add `gateway` property to `OSPMTDetailsModel` struct. When authorising payment, confirm that this property corresponds to a configured gateway (on plist).

Two Sample App builds were generated to test the new features:
- Without PSP configured: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=c8ba3d1ed9dc896fd464c2c892db2cea65856a4a
- With Stripe configured: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=9660422a071dc871e530483148ab85ed736d03b3

**_Note:_** Code coverage should be small as most of the code is covering Apple Pay specific code.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2095

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests
The existing ones were updated where needed. All are passing successfully.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
